### PR TITLE
Support optional query params

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,12 @@
+require_relative "lib/cassieq/client"
+require "yaml"
+
+CONFIG = YAML.load_file("#{Dir.pwd}/spec/config.yml")
+
+def client
+  Cassieq::Client.new do |c|
+    c.host = CONFIG["host"]
+    c.key = CONFIG["key"]
+    c.account = CONFIG["account"]
+  end
+end

--- a/cassieq-client.gemspec
+++ b/cassieq-client.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = "cassieq-client"
-  s.version = "1.0.1"
-  s.date = "2016-04-11"
+  s.version = "1.1.0"
+  s.date = "2016-04-25"
   s.summary = "CassieQ Client"
   s.description = "A Ruby wrapper for the CassieQ API"
   s.authors = ["Tom Conroy"]

--- a/lib/cassieq/client.rb
+++ b/lib/cassieq/client.rb
@@ -37,16 +37,13 @@ module Cassieq
       end
     end
 
-    def path_prefix
-      "/api/v1/accounts/#{account}"
-    end
-
-    def request(method, path, body = nil, params = {})
+    def request(method, path, body = nil, params = nil)
+      path_prefix = "/api/v1/accounts/#{account}"
       request_path = "#{path_prefix}/#{path}"
 
       handle_response do
         connection.run_request(method, request_path, body, nil) do |req|
-          req.params.merge!(params)
+          req.params.merge!(params) unless params.nil?
           req.headers.merge!(auth_headers(method, request_path)) unless key.nil?
           req.headers.merge!("Content-Type" => "application/json") unless body.nil?
         end

--- a/lib/cassieq/client/messages.rb
+++ b/lib/cassieq/client/messages.rb
@@ -3,13 +3,13 @@ require "json"
 module Cassieq
   class Client
     module Messages
-      def publish_message(queue_name, message, initial_invis_time = nil)
-        query = { initialInvisibilityTime: initial_invis_time } unless initial_invis_time.nil?
+      def publish_message(queue_name, message, initial_invis_seconds = nil)
+        query = { initialInvisibilitySeconds: initial_invis_seconds } unless initial_invis_seconds.nil?
         request(:post, "queues/#{queue_name}/messages", message, query)
       end
 
-      def next_message(queue_name, initial_invis_time = nil)
-        query = { initialInvisibilityTime: initial_invis_time } unless initial_invis_time.nil?
+      def next_message(queue_name, initial_invis_seconds = nil)
+        query = { initialInvisibilitySeconds: initial_invis_seconds } unless initial_invis_seconds.nil?
         request(:get, "queues/#{queue_name}/messages/next", nil, query)
       end
 

--- a/lib/cassieq/client/messages.rb
+++ b/lib/cassieq/client/messages.rb
@@ -3,12 +3,14 @@ require "json"
 module Cassieq
   class Client
     module Messages
-      def publish_message(queue_name, message)
-        request(:post, "queues/#{queue_name}/messages", message)
+      def publish_message(queue_name, message, initial_invis_time = nil)
+        query = { initialInvisibilityTime: initial_invis_time } unless initial_invis_time.nil?
+        request(:post, "queues/#{queue_name}/messages", message, query)
       end
 
-      def next_message(queue_name)
-        request(:get, "queues/#{queue_name}/messages/next")
+      def next_message(queue_name, initial_invis_time = nil)
+        query = { initialInvisibilityTime: initial_invis_time } unless initial_invis_time.nil?
+        request(:get, "queues/#{queue_name}/messages/next", nil, query)
       end
 
       def edit_message(queue_name, pop_receipt, options)

--- a/lib/cassieq/client/messages.rb
+++ b/lib/cassieq/client/messages.rb
@@ -12,7 +12,7 @@ module Cassieq
       end
 
       def edit_message(queue_name, pop_receipt, options)
-        body = camelize_and_stringify_keys(options).to_json
+        body = Cassieq::Utils.camelize_and_stringify_keys(options).to_json
         params = { popReceipt: pop_receipt }
         request(:put, "queues/#{queue_name}/messages", body, params)
       end

--- a/lib/cassieq/client/queues.rb
+++ b/lib/cassieq/client/queues.rb
@@ -8,7 +8,7 @@ module Cassieq
       end
 
       def create_queue(options)
-        body = camelize_and_stringify_keys(options).to_json
+        body = Cassieq::Utils.camelize_and_stringify_keys(options).to_json
         request(:post, "queues", body)
       end
 

--- a/lib/cassieq/client/queues.rb
+++ b/lib/cassieq/client/queues.rb
@@ -7,9 +7,10 @@ module Cassieq
         request(:get, "queues")
       end
 
-      def create_queue(options)
+      def create_queue(options, error_if_exists = nil)
         body = Cassieq::Utils.camelize_and_stringify_keys(options).to_json
-        request(:post, "queues", body)
+        query = { errorIfExists: error_if_exists } unless error_if_exists.nil?
+        request(:post, "queues", body, query)
       end
 
       def queue(queue_name)

--- a/lib/cassieq/utils.rb
+++ b/lib/cassieq/utils.rb
@@ -3,17 +3,17 @@ require "active_support/inflector"
 
 module Cassieq
   module Utils
-    private
-
-    def underscore_and_symobolize_keys(data)
+    def self.underscore_and_symobolize_keys(data)
       transform_keys_in_structure(data) { |key| key.underscore.to_sym }
     end
 
-    def camelize_and_stringify_keys(data)
+    def self.camelize_and_stringify_keys(data)
       transform_keys_in_structure(data) { |key| key.to_s.camelize(:lower) }
     end
 
-    def transform_keys_in_structure(data)
+    private
+
+    def self.transform_keys_in_structure(data)
       case data
       when Hash
         data.transform_keys { |key| yield(key) }

--- a/spec/cassettes/client/key_auth.yml
+++ b/spec/cassettes/client/key_auth.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:12Z'
+      - '2016-04-18T19:22:53Z'
       Authorization:
-      - Signed qRsmA8Mz80pT9zCx1RpYmS_dMh2M0xDIHS3jcyWYp5M
+      - Signed hI3jDqkBE9k0qdTXD4mjcjLJq0aVMqcaV6A2brDLZkQ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:12 GMT
+      - Mon, 18 Apr 2016 19:22:53 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -32,5 +32,5 @@ http_interactions:
       encoding: UTF-8
       string: "[ ]"
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:12 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/client/no_auth.yml
+++ b/spec/cassettes/client/no_auth.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Unauthorized
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:12 GMT
+      - Mon, 18 Apr 2016 19:22:53 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -32,5 +32,5 @@ http_interactions:
           "message" : "HTTP 401 Unauthorized"
         }
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:12 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/client/signed_query_string_auth.yml
+++ b/spec/cassettes/client/signed_query_string_auth.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:12 GMT
+      - Mon, 18 Apr 2016 19:22:53 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -28,5 +28,5 @@ http_interactions:
       encoding: UTF-8
       string: "[ ]"
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:12 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/ack_message.yml
+++ b/spec/cassettes/messages/ack_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:35Z'
+      - '2016-04-26T00:06:07Z'
       Authorization:
-      - Signed N1I954LfU5EgP3_gSngV27B5_xNyU5yoWw1FiEwBfzM
+      - Signed I6heMIJGUq7GwAmYW6J28v5O2VMcEYfKY22rh2cAdU8
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,17 +25,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:35 GMT
+      - Tue, 26 Apr 2016 00:06:07 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:07 GMT
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilityTime=0
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilitySeconds=0
     body:
       encoding: UTF-8
       string: Test message!
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:35Z'
+      - '2016-04-26T00:06:07Z'
       Authorization:
-      - Signed GZXD8e0BCZS7CBKog5lftmtgBzaQBFHv1tDLtrvvR6E
+      - Signed TTd6lnt7b6m7-VnR4NvVhL8lZePduvWeMkxH4szkmfU
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,17 +58,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:35 GMT
+      - Tue, 26 Apr 2016 00:06:07 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:07 GMT
 - request:
     method: get
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next?initialInvisibilityTime=0
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next?initialInvisibilitySeconds=0
     body:
       encoding: US-ASCII
       string: ''
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:35Z'
+      - '2016-04-26T00:06:07Z'
       Authorization:
-      - Signed T1UfMxfQmszfmStuad_wUpFDTSsb30q4dKnUb6DTsYA
+      - Signed 5JYhAoN_aQS_vOv2eUdlV1_M4g_CrK4a_Rq3Vp-wkC4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:35 GMT
+      - Tue, 26 Apr 2016 00:06:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -98,16 +98,16 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDoyOmROeXQzdw",
+          "popReceipt" : "MDoyOitoNE5wQQ",
           "message" : "Test message!",
           "deliveryCount" : 0,
-          "messageTag" : "dNyt3w"
+          "messageTag" : "+h4NpA"
         }
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:36 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:07 GMT
 - request:
     method: delete
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOmROeXQzdw
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOitoNE5wQQ
     body:
       encoding: US-ASCII
       string: ''
@@ -115,9 +115,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:36Z'
+      - '2016-04-26T00:06:07Z'
       Authorization:
-      - Signed WKvV_6sf3-43jwhwideEq5bkSLRNb2_S7co7J9sg0AY
+      - Signed vMrsHKYHiQLUkCWJRw95Ifu3Y8Z_HGljepknbeLoKf4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -128,12 +128,12 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:36 GMT
+      - Tue, 26 Apr 2016 00:06:07 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:36 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:07 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -144,9 +144,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:36Z'
+      - '2016-04-26T00:06:07Z'
       Authorization:
-      - Signed rOT_ikQjuSSNBHsLo0lNE4s9h_32hbcQsObgBgMnZDI
+      - Signed KSKsgUzYV9EE77HEEnZK1vR04Empc4ETc1UFpTLw828
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -157,12 +157,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:36 GMT
+      - Tue, 26 Apr 2016 00:06:07 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:36 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:07 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/ack_message.yml
+++ b/spec/cassettes/messages/ack_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:09Z'
+      - '2016-04-18T19:22:50Z'
       Authorization:
-      - Signed Xhs0J1c6cYCx8k4FFPo7E6Ubvh58cfa9wlzThTVby-g
+      - Signed -sqZGsl-NbKdWZsFN_FALCDivU1-EuJOEj0qU8h3gYU
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:09 GMT
+      - Mon, 18 Apr 2016 19:22:50 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:09 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
 - request:
     method: post
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:09Z'
+      - '2016-04-18T19:22:50Z'
       Authorization:
-      - Signed vAtXHIT1wvb0EGP0EiI7DGEMLMqWvBQtk-tXOwuBtAM
+      - Signed RBPQ11WMVqBVgffufp6wQT7o2OF9K1lr6TAELhPV1Tg
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,14 +58,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:09 GMT
+      - Mon, 18 Apr 2016 19:22:50 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:09 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
 - request:
     method: get
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:09Z'
+      - '2016-04-18T19:22:50Z'
       Authorization:
-      - Signed dtBq7BHrHjK6AuzR1TgugISfOPZzA55lT2brAaevgZU
+      - Signed _ps0Th_c4r3zi4iuxyIHxHzKW-HrZih5CnuWkDBPlf8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:09 GMT
+      - Mon, 18 Apr 2016 19:22:50 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -98,16 +98,16 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDoyOnlPSW1RZw",
+          "popReceipt" : "MDoyOkJLVTVPdw",
           "message" : "Test message!",
           "deliveryCount" : 0,
-          "messageTag" : "yOImQg"
+          "messageTag" : "BKU5Ow"
         }
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:09 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
 - request:
     method: delete
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOnlPSW1RZw
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOkJLVTVPdw
     body:
       encoding: US-ASCII
       string: ''
@@ -115,9 +115,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:09Z'
+      - '2016-04-18T19:22:51Z'
       Authorization:
-      - Signed pCVmwjURNK3-KCjo47POYuxEl2uBChWfLwysR-u9PWE
+      - Signed q4LvJkzwaUqzqsHpFc5Lu_TTyTBx1rHV3cD5LvbYJU4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -128,12 +128,12 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:09 GMT
+      - Mon, 18 Apr 2016 19:22:51 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:10 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -144,9 +144,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:10Z'
+      - '2016-04-18T19:22:51Z'
       Authorization:
-      - Signed 8p9_mb7pg-9MMixtA18HhYvcjT97Zoqrfn491UH2XDA
+      - Signed W04Qkgbpq_1eZTBJ300C95Btz3QVRECFI6P0y8q0_tI
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -157,12 +157,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:10 GMT
+      - Mon, 18 Apr 2016 19:22:51 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:10 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/ack_message.yml
+++ b/spec/cassettes/messages/ack_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:50Z'
+      - '2016-04-25T18:19:35Z'
       Authorization:
-      - Signed -sqZGsl-NbKdWZsFN_FALCDivU1-EuJOEj0qU8h3gYU
+      - Signed N1I954LfU5EgP3_gSngV27B5_xNyU5yoWw1FiEwBfzM
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,17 +25,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:50 GMT
+      - Mon, 25 Apr 2016 18:19:35 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilityTime=0
     body:
       encoding: UTF-8
       string: Test message!
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:50Z'
+      - '2016-04-25T18:19:35Z'
       Authorization:
-      - Signed RBPQ11WMVqBVgffufp6wQT7o2OF9K1lr6TAELhPV1Tg
+      - Signed GZXD8e0BCZS7CBKog5lftmtgBzaQBFHv1tDLtrvvR6E
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,17 +58,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:50 GMT
+      - Mon, 25 Apr 2016 18:19:35 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
 - request:
     method: get
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next?initialInvisibilityTime=0
     body:
       encoding: US-ASCII
       string: ''
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:50Z'
+      - '2016-04-25T18:19:35Z'
       Authorization:
-      - Signed _ps0Th_c4r3zi4iuxyIHxHzKW-HrZih5CnuWkDBPlf8
+      - Signed T1UfMxfQmszfmStuad_wUpFDTSsb30q4dKnUb6DTsYA
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:50 GMT
+      - Mon, 25 Apr 2016 18:19:35 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -98,16 +98,16 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDoyOkJLVTVPdw",
+          "popReceipt" : "MDoyOmROeXQzdw",
           "message" : "Test message!",
           "deliveryCount" : 0,
-          "messageTag" : "BKU5Ow"
+          "messageTag" : "dNyt3w"
         }
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:36 GMT
 - request:
     method: delete
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOkJLVTVPdw
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOmROeXQzdw
     body:
       encoding: US-ASCII
       string: ''
@@ -115,9 +115,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:51Z'
+      - '2016-04-25T18:19:36Z'
       Authorization:
-      - Signed q4LvJkzwaUqzqsHpFc5Lu_TTyTBx1rHV3cD5LvbYJU4
+      - Signed WKvV_6sf3-43jwhwideEq5bkSLRNb2_S7co7J9sg0AY
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -128,12 +128,12 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:51 GMT
+      - Mon, 25 Apr 2016 18:19:36 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:36 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -144,9 +144,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:51Z'
+      - '2016-04-25T18:19:36Z'
       Authorization:
-      - Signed W04Qkgbpq_1eZTBJ300C95Btz3QVRECFI6P0y8q0_tI
+      - Signed rOT_ikQjuSSNBHsLo0lNE4s9h_32hbcQsObgBgMnZDI
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -157,12 +157,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:51 GMT
+      - Mon, 25 Apr 2016 18:19:36 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:36 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/edit_message.yml
+++ b/spec/cassettes/messages/edit_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:08Z'
+      - '2016-04-18T19:22:49Z'
       Authorization:
-      - Signed 8RMXTw31tFGvyJ24Goh8hZ3kji0whd_oq4DjHYqjRcE
+      - Signed l6-7Xq28vpSy8sSKY3cxLjkEKXwYLaAarjLqZYBYaeg
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:08 GMT
+      - Mon, 18 Apr 2016 19:22:49 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:08 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
 - request:
     method: post
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:08Z'
+      - '2016-04-18T19:22:50Z'
       Authorization:
-      - Signed AKFX2pkzA-fHLfrLP0PjTILTk3n5RPBIeoflatlx_-A
+      - Signed RBPQ11WMVqBVgffufp6wQT7o2OF9K1lr6TAELhPV1Tg
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,14 +58,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:08 GMT
+      - Mon, 18 Apr 2016 19:22:50 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:09 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
 - request:
     method: get
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:09Z'
+      - '2016-04-18T19:22:50Z'
       Authorization:
-      - Signed dtBq7BHrHjK6AuzR1TgugISfOPZzA55lT2brAaevgZU
+      - Signed _ps0Th_c4r3zi4iuxyIHxHzKW-HrZih5CnuWkDBPlf8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:09 GMT
+      - Mon, 18 Apr 2016 19:22:50 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -98,16 +98,16 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDoyOitZNGh4QQ",
+          "popReceipt" : "MDoyOnBPRFlFUQ",
           "message" : "Test message!",
           "deliveryCount" : 0,
-          "messageTag" : "+Y4hxA"
+          "messageTag" : "pODYEQ"
         }
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:09 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
 - request:
     method: put
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOitZNGh4QQ
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOnBPRFlFUQ
     body:
       encoding: UTF-8
       string: '{"message":"Tacos tonight!"}'
@@ -115,9 +115,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:09Z'
+      - '2016-04-18T19:22:50Z'
       Authorization:
-      - Signed oOzIYNAm0p0be_NLSjuMgIYyDRbWfjqvO23SiHcKfcU
+      - Signed q8snTvYiTnqJAy5w1uAUS1K7vmHS80zNEkhap5YaJks
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -130,7 +130,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:09 GMT
+      - Mon, 18 Apr 2016 19:22:50 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -139,11 +139,11 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDozOitZNGh4QQ",
-          "messageTag" : "+Y4hxA"
+          "popReceipt" : "MDozOnBPRFlFUQ",
+          "messageTag" : "pODYEQ"
         }
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:09 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -154,9 +154,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:09Z'
+      - '2016-04-18T19:22:50Z'
       Authorization:
-      - Signed PpWvGxr26DvmaJ6AcBtwFiOpuJh3ZSPJdI4uait4Gqc
+      - Signed InARxUrhm5XxtJfUz-3Oh3rbDilP4AYUJfo2xOlfVPw
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -167,12 +167,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:09 GMT
+      - Mon, 18 Apr 2016 19:22:50 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:09 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/edit_message.yml
+++ b/spec/cassettes/messages/edit_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:34Z'
+      - '2016-04-26T00:06:06Z'
       Authorization:
-      - Signed 8UryMWRGCHUYxGhH9LXtatxNChKu-eGK0YKlZOtY6KI
+      - Signed umCSuTinwKM4K-x3MxJ_urlrFXtVJOrSwN93D2WRAbM
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,17 +25,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:34 GMT
+      - Tue, 26 Apr 2016 00:06:06 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:06 GMT
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilityTime=0
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilitySeconds=0
     body:
       encoding: UTF-8
       string: Test message!
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:35Z'
+      - '2016-04-26T00:06:06Z'
       Authorization:
-      - Signed GZXD8e0BCZS7CBKog5lftmtgBzaQBFHv1tDLtrvvR6E
+      - Signed tsJtF5ohySqAqlHiO9jteaNUtaiJiPxKhEJDJk7NRWA
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,17 +58,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:35 GMT
+      - Tue, 26 Apr 2016 00:06:06 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:06 GMT
 - request:
     method: get
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next?initialInvisibilityTime=0
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next?initialInvisibilitySeconds=0
     body:
       encoding: US-ASCII
       string: ''
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:35Z'
+      - '2016-04-26T00:06:06Z'
       Authorization:
-      - Signed T1UfMxfQmszfmStuad_wUpFDTSsb30q4dKnUb6DTsYA
+      - Signed 2924guennZ6TiIjsmc_ZQ6NeJn_NTTbVk-KcUGF6FS8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:35 GMT
+      - Tue, 26 Apr 2016 00:06:06 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -98,16 +98,16 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDoyOkNDdnBqQQ",
+          "popReceipt" : "MDoyOnp4NURSUQ",
           "message" : "Test message!",
           "deliveryCount" : 0,
-          "messageTag" : "CCvpjA"
+          "messageTag" : "zx5DRQ"
         }
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:06 GMT
 - request:
     method: put
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOkNDdnBqQQ
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOnp4NURSUQ
     body:
       encoding: UTF-8
       string: '{"message":"Tacos tonight!"}'
@@ -115,9 +115,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:35Z'
+      - '2016-04-26T00:06:06Z'
       Authorization:
-      - Signed h9ypj56C5NrtfOvMmlecqHSW_NT5brnzZYhZv3psYwk
+      - Signed Zo7t9Kn8SIE-6bLaGjtCayO6Ly0Y3pfk112x8y1B0Sk
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -130,7 +130,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:35 GMT
+      - Tue, 26 Apr 2016 00:06:06 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -139,11 +139,11 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDozOkNDdnBqQQ",
-          "messageTag" : "CCvpjA"
+          "popReceipt" : "MDozOnp4NURSUQ",
+          "messageTag" : "zx5DRQ"
         }
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:06 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -154,9 +154,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:35Z'
+      - '2016-04-26T00:06:06Z'
       Authorization:
-      - Signed aLhNS9cj5oylLjDB6Re3m11o4bF5grrFn3N2LvmMiSU
+      - Signed tb2k6QKhCiQ6Rn4wnIQgeKusX95boYDCTLndOnqLsRs
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -167,12 +167,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:35 GMT
+      - Tue, 26 Apr 2016 00:06:06 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:07 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/edit_message.yml
+++ b/spec/cassettes/messages/edit_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:49Z'
+      - '2016-04-25T18:19:34Z'
       Authorization:
-      - Signed l6-7Xq28vpSy8sSKY3cxLjkEKXwYLaAarjLqZYBYaeg
+      - Signed 8UryMWRGCHUYxGhH9LXtatxNChKu-eGK0YKlZOtY6KI
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,17 +25,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:49 GMT
+      - Mon, 25 Apr 2016 18:19:34 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilityTime=0
     body:
       encoding: UTF-8
       string: Test message!
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:50Z'
+      - '2016-04-25T18:19:35Z'
       Authorization:
-      - Signed RBPQ11WMVqBVgffufp6wQT7o2OF9K1lr6TAELhPV1Tg
+      - Signed GZXD8e0BCZS7CBKog5lftmtgBzaQBFHv1tDLtrvvR6E
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,17 +58,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:50 GMT
+      - Mon, 25 Apr 2016 18:19:35 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
 - request:
     method: get
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next?initialInvisibilityTime=0
     body:
       encoding: US-ASCII
       string: ''
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:50Z'
+      - '2016-04-25T18:19:35Z'
       Authorization:
-      - Signed _ps0Th_c4r3zi4iuxyIHxHzKW-HrZih5CnuWkDBPlf8
+      - Signed T1UfMxfQmszfmStuad_wUpFDTSsb30q4dKnUb6DTsYA
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:50 GMT
+      - Mon, 25 Apr 2016 18:19:35 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -98,16 +98,16 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDoyOnBPRFlFUQ",
+          "popReceipt" : "MDoyOkNDdnBqQQ",
           "message" : "Test message!",
           "deliveryCount" : 0,
-          "messageTag" : "pODYEQ"
+          "messageTag" : "CCvpjA"
         }
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
 - request:
     method: put
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOnBPRFlFUQ
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?popReceipt=MDoyOkNDdnBqQQ
     body:
       encoding: UTF-8
       string: '{"message":"Tacos tonight!"}'
@@ -115,9 +115,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:50Z'
+      - '2016-04-25T18:19:35Z'
       Authorization:
-      - Signed q8snTvYiTnqJAy5w1uAUS1K7vmHS80zNEkhap5YaJks
+      - Signed h9ypj56C5NrtfOvMmlecqHSW_NT5brnzZYhZv3psYwk
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -130,7 +130,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:50 GMT
+      - Mon, 25 Apr 2016 18:19:35 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -139,11 +139,11 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDozOnBPRFlFUQ",
-          "messageTag" : "pODYEQ"
+          "popReceipt" : "MDozOkNDdnBqQQ",
+          "messageTag" : "CCvpjA"
         }
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -154,9 +154,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:50Z'
+      - '2016-04-25T18:19:35Z'
       Authorization:
-      - Signed InARxUrhm5XxtJfUz-3Oh3rbDilP4AYUJfo2xOlfVPw
+      - Signed aLhNS9cj5oylLjDB6Re3m11o4bF5grrFn3N2LvmMiSU
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -167,12 +167,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:50 GMT
+      - Mon, 25 Apr 2016 18:19:35 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:50 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:35 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/next_message.yml
+++ b/spec/cassettes/messages/next_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:07Z'
+      - '2016-04-18T19:22:49Z'
       Authorization:
-      - Signed PA7tBHyXt_6h2H2UiWHasfCDlZmxWtb_fDElHFj_Bew
+      - Signed l6-7Xq28vpSy8sSKY3cxLjkEKXwYLaAarjLqZYBYaeg
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:07 GMT
+      - Mon, 18 Apr 2016 19:22:49 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:08 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
 - request:
     method: post
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:08Z'
+      - '2016-04-18T19:22:49Z'
       Authorization:
-      - Signed AKFX2pkzA-fHLfrLP0PjTILTk3n5RPBIeoflatlx_-A
+      - Signed 0n7J18r1lNmgg1KPi1Lw4-Mlpv8jJGasvPK5LJSMi6U
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,14 +58,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:08 GMT
+      - Mon, 18 Apr 2016 19:22:49 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:08 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
 - request:
     method: get
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:08Z'
+      - '2016-04-18T19:22:49Z'
       Authorization:
-      - Signed Fpk68RrXyVn0KiotKSQPcAiU_FAOO5PlMgOl2L1pN4Q
+      - Signed MPiFjptr1i0dZ-X_VMOMHj1Z2AJ3Z8W_9HekZzIqSCE
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:08 GMT
+      - Mon, 18 Apr 2016 19:22:49 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -98,13 +98,13 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDoyOklwQk5GUQ",
+          "popReceipt" : "MDoyOm54WHNOZw",
           "message" : "Test message!",
           "deliveryCount" : 0,
-          "messageTag" : "IpBNFQ"
+          "messageTag" : "nxXsNg"
         }
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:08 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -115,9 +115,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:08Z'
+      - '2016-04-18T19:22:49Z'
       Authorization:
-      - Signed 4KuGpQYb6fJh6tz0amNyOy6psYGk2Mo6Uyvzb62uGHQ
+      - Signed uMIxgL26129gseIgQ2CqRiqlME9HVtpKOQmxMkMowfU
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -128,12 +128,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:08 GMT
+      - Mon, 18 Apr 2016 19:22:49 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:08 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/next_message.yml
+++ b/spec/cassettes/messages/next_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:49Z'
+      - '2016-04-25T18:19:34Z'
       Authorization:
-      - Signed l6-7Xq28vpSy8sSKY3cxLjkEKXwYLaAarjLqZYBYaeg
+      - Signed 8UryMWRGCHUYxGhH9LXtatxNChKu-eGK0YKlZOtY6KI
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,17 +25,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:49 GMT
+      - Mon, 25 Apr 2016 18:19:34 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilityTime=0
     body:
       encoding: UTF-8
       string: Test message!
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:49Z'
+      - '2016-04-25T18:19:34Z'
       Authorization:
-      - Signed 0n7J18r1lNmgg1KPi1Lw4-Mlpv8jJGasvPK5LJSMi6U
+      - Signed BrrBMbG_dG6BhXMpx1_SS9XxIaJUEB7U5aNCU22gOks
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,17 +58,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:49 GMT
+      - Mon, 25 Apr 2016 18:19:34 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
 - request:
     method: get
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next?initialInvisibilityTime=0
     body:
       encoding: US-ASCII
       string: ''
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:49Z'
+      - '2016-04-25T18:19:34Z'
       Authorization:
-      - Signed MPiFjptr1i0dZ-X_VMOMHj1Z2AJ3Z8W_9HekZzIqSCE
+      - Signed 1--W4loHCEO7GYXdygcmjHYXKiVJCRPc8NalwYMlelU
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:49 GMT
+      - Mon, 25 Apr 2016 18:19:34 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -98,13 +98,13 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDoyOm54WHNOZw",
+          "popReceipt" : "MDoyOllXbEZBdw",
           "message" : "Test message!",
           "deliveryCount" : 0,
-          "messageTag" : "nxXsNg"
+          "messageTag" : "YWlFAw"
         }
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -115,9 +115,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:49Z'
+      - '2016-04-25T18:19:34Z'
       Authorization:
-      - Signed uMIxgL26129gseIgQ2CqRiqlME9HVtpKOQmxMkMowfU
+      - Signed kMMUCBST-VbxAO_oLsfdTXNQNGh68rroAB4yIzslFQw
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -128,12 +128,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:49 GMT
+      - Mon, 25 Apr 2016 18:19:34 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/next_message.yml
+++ b/spec/cassettes/messages/next_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:34Z'
+      - '2016-04-26T00:06:05Z'
       Authorization:
-      - Signed 8UryMWRGCHUYxGhH9LXtatxNChKu-eGK0YKlZOtY6KI
+      - Signed dY5E4Yb7uYXUYGZdndLjHpx0CFqk9pwR0upivSKbr4I
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,17 +25,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:34 GMT
+      - Tue, 26 Apr 2016 00:06:05 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:05 GMT
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilityTime=0
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilitySeconds=0
     body:
       encoding: UTF-8
       string: Test message!
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:34Z'
+      - '2016-04-26T00:06:05Z'
       Authorization:
-      - Signed BrrBMbG_dG6BhXMpx1_SS9XxIaJUEB7U5aNCU22gOks
+      - Signed AO67N2bCosAVQO26-cf6g-JSEfkB1hfRO46-cwfH6xU
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,17 +58,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:34 GMT
+      - Tue, 26 Apr 2016 00:06:05 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:05 GMT
 - request:
     method: get
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next?initialInvisibilityTime=0
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages/next?initialInvisibilitySeconds=0
     body:
       encoding: US-ASCII
       string: ''
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:34Z'
+      - '2016-04-26T00:06:05Z'
       Authorization:
-      - Signed 1--W4loHCEO7GYXdygcmjHYXKiVJCRPc8NalwYMlelU
+      - Signed ZhXguVi2OLLkmBXObRWOTwNdtHCDunuTIvC9IriDUGQ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:34 GMT
+      - Tue, 26 Apr 2016 00:06:05 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -98,13 +98,13 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "popReceipt" : "MDoyOllXbEZBdw",
+          "popReceipt" : "MDoyOlR4UzNLdw",
           "message" : "Test message!",
           "deliveryCount" : 0,
-          "messageTag" : "YWlFAw"
+          "messageTag" : "TxS3Kw"
         }
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:05 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -115,9 +115,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:34Z'
+      - '2016-04-26T00:06:05Z'
       Authorization:
-      - Signed kMMUCBST-VbxAO_oLsfdTXNQNGh68rroAB4yIzslFQw
+      - Signed MO0e-MRHMHiQKAjWh6Mqp5MOLdHqyDjQzaDynCcEqng
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -128,12 +128,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:34 GMT
+      - Tue, 26 Apr 2016 00:06:05 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:06 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/publish_message.yml
+++ b/spec/cassettes/messages/publish_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:33Z'
+      - '2016-04-26T00:06:03Z'
       Authorization:
-      - Signed 51tBybD7-3MUiODgnOwwRV2kUtiix-8ZwpXtsEnQqSo
+      - Signed xsfqrxz65n-4w549INA6Jayfpsj7VkX3RC__ZcTq2Tk
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,17 +25,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:33 GMT
+      - Tue, 26 Apr 2016 00:06:03 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:33 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:04 GMT
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilityTime=0
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilitySeconds=0
     body:
       encoding: UTF-8
       string: Test message!
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:33Z'
+      - '2016-04-26T00:06:04Z'
       Authorization:
-      - Signed u7fxLJKuzbohpBKohY9Br0LR0vTImlE0Vv8s9mH7KfY
+      - Signed JpAmEz5W1Dz-XYfxLe87b1IJFioSEosHo8bGJ1ooaJE
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,14 +58,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:33 GMT
+      - Tue, 26 Apr 2016 00:06:04 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:04 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-25T18:19:34Z'
+      - '2016-04-26T00:06:04Z'
       Authorization:
-      - Signed kMMUCBST-VbxAO_oLsfdTXNQNGh68rroAB4yIzslFQw
+      - Signed -unGAsO03tscsmpmevElwEWeYuQQfmTT4rUcsey8y0w
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,12 +89,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 25 Apr 2016 18:19:34 GMT
+      - Tue, 26 Apr 2016 00:06:04 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
+  recorded_at: Tue, 26 Apr 2016 00:06:05 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/publish_message.yml
+++ b/spec/cassettes/messages/publish_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:48Z'
+      - '2016-04-25T18:19:33Z'
       Authorization:
-      - Signed qyowKza5l4SR3bJX3T52vtMRyzNDroG-zDSk3oa8a80
+      - Signed 51tBybD7-3MUiODgnOwwRV2kUtiix-8ZwpXtsEnQqSo
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,17 +25,17 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:48 GMT
+      - Mon, 25 Apr 2016 18:19:33 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:48 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:33 GMT
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages?initialInvisibilityTime=0
     body:
       encoding: UTF-8
       string: Test message!
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:48Z'
+      - '2016-04-25T18:19:33Z'
       Authorization:
-      - Signed 4rVrAxvqXbDQon6ucLrXpJBhtkU6QZsYBRUTrHpJeAM
+      - Signed u7fxLJKuzbohpBKohY9Br0LR0vTImlE0Vv8s9mH7KfY
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,14 +58,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:48 GMT
+      - Mon, 25 Apr 2016 18:19:33 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:48 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:48Z'
+      - '2016-04-25T18:19:34Z'
       Authorization:
-      - Signed JGqVd-FR2fbXkXqTJ_FzoMMsLgUvQKmz16RHCDA6Ew8
+      - Signed kMMUCBST-VbxAO_oLsfdTXNQNGh68rroAB4yIzslFQw
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,12 +89,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:48 GMT
+      - Mon, 25 Apr 2016 18:19:34 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
+  recorded_at: Mon, 25 Apr 2016 18:19:34 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/messages/publish_message.yml
+++ b/spec/cassettes/messages/publish_message.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:07Z'
+      - '2016-04-18T19:22:48Z'
       Authorization:
-      - Signed PA7tBHyXt_6h2H2UiWHasfCDlZmxWtb_fDElHFj_Bew
+      - Signed qyowKza5l4SR3bJX3T52vtMRyzNDroG-zDSk3oa8a80
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:07 GMT
+      - Mon, 18 Apr 2016 19:22:48 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:07 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:48 GMT
 - request:
     method: post
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:07Z'
+      - '2016-04-18T19:22:48Z'
       Authorization:
-      - Signed 2sXHM7aVFZSK905bZBvqQ5kIAskC4gV631ugVSp30vA
+      - Signed 4rVrAxvqXbDQon6ucLrXpJBhtkU6QZsYBRUTrHpJeAM
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,14 +58,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:07 GMT
+      - Mon, 18 Apr 2016 19:22:48 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:07 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:48 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:07Z'
+      - '2016-04-18T19:22:48Z'
       Authorization:
-      - Signed csO3rBb-tjDIL5bP02LEl6hEqI_htaMMRFx7zRQThEM
+      - Signed JGqVd-FR2fbXkXqTJ_FzoMMsLgUvQKmz16RHCDA6Ew8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,12 +89,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:07 GMT
+      - Mon, 18 Apr 2016 19:22:48 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:07 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:49 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/queues/create_queue.yml
+++ b/spec/cassettes/queues/create_queue.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues?errorIfExists=true
     body:
       encoding: UTF-8
       string: '{"queueName":"test_queue"}'
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:51Z'
+      - '2016-04-25T18:06:54Z'
       Authorization:
-      - Signed _cZ3VxS1gXpZ3NX8j0-rZpvYXqZCnhnjyG7MMQntUSs
+      - Signed ShP4JX2402MUUSi85xTd_T67uC2WsRbuPYmBACexiFY
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:51 GMT
+      - Mon, 25 Apr 2016 18:06:54 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:54 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:51Z'
+      - '2016-04-25T18:06:54Z'
       Authorization:
-      - Signed W04Qkgbpq_1eZTBJ300C95Btz3QVRECFI6P0y8q0_tI
+      - Signed NxsTBB4xcktEI1ZEK6EcW_DCWhunj_S3NZcsJEtdFEs
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -56,12 +56,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:51 GMT
+      - Mon, 25 Apr 2016 18:06:54 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:54 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/queues/create_queue.yml
+++ b/spec/cassettes/queues/create_queue.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:10Z'
+      - '2016-04-18T19:22:51Z'
       Authorization:
-      - Signed NCgJCXIqXhBUshO7FNlaNNGEVXxboK4O5tg4ibqo5ME
+      - Signed _cZ3VxS1gXpZ3NX8j0-rZpvYXqZCnhnjyG7MMQntUSs
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:10 GMT
+      - Mon, 18 Apr 2016 19:22:51 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:10 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:10Z'
+      - '2016-04-18T19:22:51Z'
       Authorization:
-      - Signed 8p9_mb7pg-9MMixtA18HhYvcjT97Zoqrfn491UH2XDA
+      - Signed W04Qkgbpq_1eZTBJ300C95Btz3QVRECFI6P0y8q0_tI
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -56,12 +56,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:10 GMT
+      - Mon, 18 Apr 2016 19:22:51 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:10 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:51 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/queues/delete_queue.yml
+++ b/spec/cassettes/queues/delete_queue.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:11Z'
+      - '2016-04-18T19:22:52Z'
       Authorization:
-      - Signed smxpy9my1EIInq6nKc6Fcig5Ws2kjJ5-1jq0nMNVBBg
+      - Signed FazMWkONCEQ_b1J3MWeBVAojKpzceP9UlKe_WnRgaDc
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:11 GMT
+      - Mon, 18 Apr 2016 19:22:52 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:11 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:11Z'
+      - '2016-04-18T19:22:53Z'
       Authorization:
-      - Signed U-wdRTs5fR_p-ZzEyMWJ_nfDFsit4SUhpeQAG2nuc4o
+      - Signed ve1NTvrnhU6j02SyxEYGYfYLqPi50a6_aQRDi3YGpck
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -56,12 +56,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:11 GMT
+      - Mon, 18 Apr 2016 19:22:53 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:11 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/queues/delete_queue.yml
+++ b/spec/cassettes/queues/delete_queue.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues?errorIfExists=true
     body:
       encoding: UTF-8
       string: '{"queueName":"test_queue"}'
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:52Z'
+      - '2016-04-25T18:06:55Z'
       Authorization:
-      - Signed FazMWkONCEQ_b1J3MWeBVAojKpzceP9UlKe_WnRgaDc
+      - Signed esTMAerS5a2DfhaIEvhK5evSBA4OcsMTChWtTfg4c0I
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:52 GMT
+      - Mon, 25 Apr 2016 18:06:55 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:55 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:53Z'
+      - '2016-04-25T18:06:55Z'
       Authorization:
-      - Signed ve1NTvrnhU6j02SyxEYGYfYLqPi50a6_aQRDi3YGpck
+      - Signed sjeki7VkMjfFqehQPClFkrQTUm-XyhVeKzcYrrwOMUU
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -56,12 +56,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:53 GMT
+      - Mon, 25 Apr 2016 18:06:55 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:55 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/queues/queue.yml
+++ b/spec/cassettes/queues/queue.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:11Z'
+      - '2016-04-18T19:22:52Z'
       Authorization:
-      - Signed smxpy9my1EIInq6nKc6Fcig5Ws2kjJ5-1jq0nMNVBBg
+      - Signed FazMWkONCEQ_b1J3MWeBVAojKpzceP9UlKe_WnRgaDc
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:11 GMT
+      - Mon, 18 Apr 2016 19:22:52 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:11 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
 - request:
     method: get
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:11Z'
+      - '2016-04-18T19:22:52Z'
       Authorization:
-      - Signed c-3f8tRJIvDSTCODeVrJPNMgfouCTGkqocYTrBN2ZP0
+      - Signed YT8iZ7sd90y_YQ7eunzJniIWkhMx94gpYkPdU8ym_XU
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -56,13 +56,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:11 GMT
+      - Mon, 18 Apr 2016 19:22:52 GMT
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '275'
+      - '274'
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -76,13 +76,13 @@ http_interactions:
           "repairWorkerPollFrequencySeconds" : 5,
           "repairWorkerTombstonedBucketTimeoutSeconds" : 15,
           "deleteBucketsAfterFinalization" : true,
-          "queueStatsId" : "ee60a38f-5a64-430c-9426-999816cd6896_<ACCOUNT>:test_queue_v0",
+          "queueStatsId" : "6d94e490-00ab-49e1-af3e-9f1bdbd8d434_<ACCOUNT>:test_queue_v0",
           "dlqName" : null,
           "strictFifo" : false,
           "id" : "<ACCOUNT>:test_queue_v0"
         }
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:11 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -93,9 +93,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:11Z'
+      - '2016-04-18T19:22:52Z'
       Authorization:
-      - Signed U-wdRTs5fR_p-ZzEyMWJ_nfDFsit4SUhpeQAG2nuc4o
+      - Signed YjjSRymeYWiP61eCcEeNJIrEq8BigGt5gh-0psKWuDU
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -106,12 +106,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:11 GMT
+      - Mon, 18 Apr 2016 19:22:52 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:11 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/queues/queue.yml
+++ b/spec/cassettes/queues/queue.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues?errorIfExists=true
     body:
       encoding: UTF-8
       string: '{"queueName":"test_queue"}'
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:52Z'
+      - '2016-04-25T18:06:54Z'
       Authorization:
-      - Signed FazMWkONCEQ_b1J3MWeBVAojKpzceP9UlKe_WnRgaDc
+      - Signed ShP4JX2402MUUSi85xTd_T67uC2WsRbuPYmBACexiFY
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:52 GMT
+      - Mon, 25 Apr 2016 18:06:54 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:55 GMT
 - request:
     method: get
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:52Z'
+      - '2016-04-25T18:06:55Z'
       Authorization:
-      - Signed YT8iZ7sd90y_YQ7eunzJniIWkhMx94gpYkPdU8ym_XU
+      - Signed QjgrDQqlSCxdwSZhRC1NQseZCsvEqmTxGjX2-Y41WdI
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -56,7 +56,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:52 GMT
+      - Mon, 25 Apr 2016 18:06:55 GMT
       Content-Type:
       - application/json
       Vary:
@@ -76,13 +76,13 @@ http_interactions:
           "repairWorkerPollFrequencySeconds" : 5,
           "repairWorkerTombstonedBucketTimeoutSeconds" : 15,
           "deleteBucketsAfterFinalization" : true,
-          "queueStatsId" : "6d94e490-00ab-49e1-af3e-9f1bdbd8d434_<ACCOUNT>:test_queue_v0",
+          "queueStatsId" : "e5d1df4c-d295-4129-8d27-6e5d287f01cc_<ACCOUNT>:test_queue_v0",
           "dlqName" : null,
           "strictFifo" : false,
           "id" : "<ACCOUNT>:test_queue_v0"
         }
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:55 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -93,9 +93,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:52Z'
+      - '2016-04-25T18:06:55Z'
       Authorization:
-      - Signed YjjSRymeYWiP61eCcEeNJIrEq8BigGt5gh-0psKWuDU
+      - Signed sjeki7VkMjfFqehQPClFkrQTUm-XyhVeKzcYrrwOMUU
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -106,12 +106,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:52 GMT
+      - Mon, 25 Apr 2016 18:06:55 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:55 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/queues/queues.yml
+++ b/spec/cassettes/queues/queues.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:10Z'
+      - '2016-04-18T19:22:51Z'
       Authorization:
-      - Signed NCgJCXIqXhBUshO7FNlaNNGEVXxboK4O5tg4ibqo5ME
+      - Signed _cZ3VxS1gXpZ3NX8j0-rZpvYXqZCnhnjyG7MMQntUSs
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:10 GMT
+      - Mon, 18 Apr 2016 19:22:51 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:10 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
 - request:
     method: get
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:10Z'
+      - '2016-04-18T19:22:52Z'
       Authorization:
-      - Signed LccyJud2C-4qdFM-xNDP7GR9YEOrELTYGtXERLpvIFQ
+      - Signed tP0Brvq3bN767tZA9P1AapVkNUfn5Pq8vlqMARX-dJo
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -56,13 +56,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:10 GMT
+      - Mon, 18 Apr 2016 19:22:52 GMT
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '281'
+      - '278'
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -76,13 +76,13 @@ http_interactions:
           "repairWorkerPollFrequencySeconds" : 5,
           "repairWorkerTombstonedBucketTimeoutSeconds" : 15,
           "deleteBucketsAfterFinalization" : true,
-          "queueStatsId" : "0fdb2f8e-657c-476c-a899-513e28f56c66_<ACCOUNT>:test_queue_v0",
+          "queueStatsId" : "eeaa2ac7-38d7-48ef-aa3c-f7531bcf67ca_<ACCOUNT>:test_queue_v0",
           "dlqName" : null,
           "strictFifo" : false,
           "id" : "<ACCOUNT>:test_queue_v0"
         } ]
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:10 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -93,9 +93,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:10Z'
+      - '2016-04-18T19:22:52Z'
       Authorization:
-      - Signed 8p9_mb7pg-9MMixtA18HhYvcjT97Zoqrfn491UH2XDA
+      - Signed YjjSRymeYWiP61eCcEeNJIrEq8BigGt5gh-0psKWuDU
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -106,12 +106,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:10 GMT
+      - Mon, 18 Apr 2016 19:22:52 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:11 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/queues/queues.yml
+++ b/spec/cassettes/queues/queues.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues
+    uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues?errorIfExists=true
     body:
       encoding: UTF-8
       string: '{"queueName":"test_queue"}'
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:51Z'
+      - '2016-04-25T18:06:54Z'
       Authorization:
-      - Signed _cZ3VxS1gXpZ3NX8j0-rZpvYXqZCnhnjyG7MMQntUSs
+      - Signed ShP4JX2402MUUSi85xTd_T67uC2WsRbuPYmBACexiFY
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:51 GMT
+      - Mon, 25 Apr 2016 18:06:54 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:54 GMT
 - request:
     method: get
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:52Z'
+      - '2016-04-25T18:06:54Z'
       Authorization:
-      - Signed tP0Brvq3bN767tZA9P1AapVkNUfn5Pq8vlqMARX-dJo
+      - Signed BxWfVf7Ohn6XNUezlTvOl_27ASOhFLfLHUoGSl32l4c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -56,13 +56,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:52 GMT
+      - Mon, 25 Apr 2016 18:06:54 GMT
       Content-Type:
       - application/json
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '278'
+      - '280'
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -76,13 +76,13 @@ http_interactions:
           "repairWorkerPollFrequencySeconds" : 5,
           "repairWorkerTombstonedBucketTimeoutSeconds" : 15,
           "deleteBucketsAfterFinalization" : true,
-          "queueStatsId" : "eeaa2ac7-38d7-48ef-aa3c-f7531bcf67ca_<ACCOUNT>:test_queue_v0",
+          "queueStatsId" : "0f66c78a-a931-4944-92d9-eef8df1a464f_<ACCOUNT>:test_queue_v0",
           "dlqName" : null,
           "strictFifo" : false,
           "id" : "<ACCOUNT>:test_queue_v0"
         } ]
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:54 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -93,9 +93,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-18T19:22:52Z'
+      - '2016-04-25T18:06:54Z'
       Authorization:
-      - Signed YjjSRymeYWiP61eCcEeNJIrEq8BigGt5gh-0psKWuDU
+      - Signed NxsTBB4xcktEI1ZEK6EcW_DCWhunj_S3NZcsJEtdFEs
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -106,12 +106,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Apr 2016 19:22:52 GMT
+      - Mon, 25 Apr 2016 18:06:54 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 18 Apr 2016 19:22:52 GMT
+  recorded_at: Mon, 25 Apr 2016 18:06:54 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/statistics/statistics.yml
+++ b/spec/cassettes/statistics/statistics.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:11Z'
+      - '2016-04-18T19:22:53Z'
       Authorization:
-      - Signed smxpy9my1EIInq6nKc6Fcig5Ws2kjJ5-1jq0nMNVBBg
+      - Signed GdzpbmzPdzpXyb-Pdy45IPi7_dYB9rBiKf1jY50JWLw
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -25,14 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:11 GMT
+      - Mon, 18 Apr 2016 19:22:53 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:12 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
 - request:
     method: post
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/messages
@@ -43,9 +43,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:12Z'
+      - '2016-04-18T19:22:53Z'
       Authorization:
-      - Signed ZEAaejcwpMp-PQQNSzMr6IJz_L6Wf-4m3rwZMwEzY3o
+      - Signed vYCFA1LpPRvhKF_b_Bk7Twzqid2w-zba_DIIAcuhDiM
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -58,14 +58,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:12 GMT
+      - Mon, 18 Apr 2016 19:22:53 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:12 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
 - request:
     method: get
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue/statistics
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:12Z'
+      - '2016-04-18T19:22:53Z'
       Authorization:
-      - Signed QvhV5qr7KvaRHlb6hs36fvFdjXsFGGQeO55fWSiyLpg
+      - Signed BglNDIFQXh91DPGJw5g-om0nZdJZlvUkfgQDRL4z7xE
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -89,7 +89,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:12 GMT
+      - Mon, 18 Apr 2016 19:22:53 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -101,7 +101,7 @@ http_interactions:
           "size" : 1
         }
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:12 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
 - request:
     method: delete
     uri: http://<HOST>:8080/api/v1/accounts/<ACCOUNT>/queues/test_queue
@@ -112,9 +112,9 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       X-Cassieq-Request-Time:
-      - '2016-04-12T02:03:12Z'
+      - '2016-04-18T19:22:53Z'
       Authorization:
-      - Signed dN_Y2N9pjvEHkv2qSxpABAZAFOx1U2pPemi-PnIlGNE
+      - Signed ve1NTvrnhU6j02SyxEYGYfYLqPi50a6_aQRDi3YGpck
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -125,12 +125,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Apr 2016 02:03:12 GMT
+      - Mon, 18 Apr 2016 19:22:53 GMT
       Content-Length:
       - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 02:03:12 GMT
+  recorded_at: Mon, 18 Apr 2016 19:22:53 GMT
 recorded_with: VCR 3.0.1

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -5,5 +5,5 @@
 
 host: 192.168.99.100
 account: test-account
-key: C3RAOAbRVT-MBe7DL491-3oAzNJrzhqcYRANlNPqvSPcCUtTYa7flyhDpSPEM01b4bzNaQL1uvLMm5y4HDY3bA
-provided_params: auth=g&sig=JkGhEjsPBwrRbo2UGEwQd1vAaMfD_IrlKk3LkPxoDgA
+key: A1wOkHNznfi131jjuHmd61OQKPq5Su0hJVUf8WvmKHGHQMT5scgTeiDJWEBE-jt5nNzHMKBAu0pRC9aChxpLrQ
+provided_params: auth=g&sig=MkvORZbS11AS-pM1vFjfPPSdKEMSON6bPN6pF7n4zv0

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -5,5 +5,5 @@
 
 host: 192.168.99.100
 account: test-account
-key: A1wOkHNznfi131jjuHmd61OQKPq5Su0hJVUf8WvmKHGHQMT5scgTeiDJWEBE-jt5nNzHMKBAu0pRC9aChxpLrQ
-provided_params: auth=g&sig=MkvORZbS11AS-pM1vFjfPPSdKEMSON6bPN6pF7n4zv0
+key: UrZCQ76KourlQIYcw8W_k0vJN5Rqv-29Fd7b6BvXn-AsOi-pCPRJTmOdR5NigW7U0PsdWr_YAw1EF_yMBNdhZw
+provided_params: auth=g&sig=2kcHP6hkdsonJ2f_-Q8DOfu0a_fLZajLm67RrpMZeko

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -5,5 +5,5 @@
 
 host: 192.168.99.100
 account: test-account
-key: fClvRAuDTmiWX7wRG-hhA8mmqF0KZbnsNxRCMPCha3AzE5W0malv8x28_PY6rIWutsxHtW1e8BvDyxGv1EmYaw
-provided_params: auth=g&sig=mwsVKi-HsuVs1v-wvkuNmcPS4T2vstU2WwkRNDOdWrM
+key: C3RAOAbRVT-MBe7DL491-3oAzNJrzhqcYRANlNPqvSPcCUtTYa7flyhDpSPEM01b4bzNaQL1uvLMm5y4HDY3bA
+provided_params: auth=g&sig=JkGhEjsPBwrRbo2UGEwQd1vAaMfD_IrlKk3LkPxoDgA

--- a/spec/lib/cassieq/client/messages_spec.rb
+++ b/spec/lib/cassieq/client/messages_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 RSpec.describe Cassieq::Client::Messages do
   let(:client) { Cassieq::Client.new(host: CONFIG["host"], account: CONFIG["account"], key: CONFIG["key"] )}
-  let(:publish_message) { client.publish_message("test_queue", "Test message!") }
-  let(:next_message) { client.next_message("test_queue") }
+  let(:publish_message) { client.publish_message("test_queue", "Test message!", 0) }
+  let(:next_message) { client.next_message("test_queue", 0) }
 
   before(:each) { client.create_queue(queue_name: "test_queue") }
   after(:each) { client.delete_queue("test_queue") }

--- a/spec/lib/cassieq/client/queues_spec.rb
+++ b/spec/lib/cassieq/client/queues_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Cassieq::Client::Queues do
   let(:client) { Cassieq::Client.new(host: CONFIG["host"], account: CONFIG["account"], key: CONFIG["key"] )}
-  let(:create_queue) { client.create_queue(queue_name: "test_queue") }
+  let(:create_queue) { client.create_queue({ queue_name: "test_queue" }, true) }
   let(:delete_queue) { client.delete_queue("test_queue") }
 
   describe "#create_queue", vcr: { cassette_name: "queues/create_queue" } do

--- a/spec/lib/cassieq/utils_spec.rb
+++ b/spec/lib/cassieq/utils_spec.rb
@@ -2,18 +2,20 @@ require "spec_helper"
 include Cassieq::Utils
 
 RSpec.describe Cassieq::Utils do
+  let(:utils) { Cassieq::Utils }
+
   describe "#underscore_and_symobolize_keys" do
     context "structure is a single hash" do
       it "transforms the keys" do
         data = { "joeCamelCase" => "what", "ninjaTurtles" => "cowabunga" }
-        expect(underscore_and_symobolize_keys(data)).to eq(joe_camel_case: "what", ninja_turtles: "cowabunga")
+        expect(utils.underscore_and_symobolize_keys(data)).to eq(joe_camel_case: "what", ninja_turtles: "cowabunga")
       end
     end
 
     context "structure is hashes nested in an array" do
       it "transforms the keys" do
         data = [{ "joeCamelCase" => "what" }, { "ninjaTurtles" => "cowabunga" }]
-        expect(underscore_and_symobolize_keys(data)).to eq([{ joe_camel_case: "what" }, { ninja_turtles: "cowabunga" }])
+        expect(utils.underscore_and_symobolize_keys(data)).to eq([{ joe_camel_case: "what" }, { ninja_turtles: "cowabunga" }])
       end
     end
   end
@@ -22,14 +24,14 @@ RSpec.describe Cassieq::Utils do
     context "structure is a single hash" do
       it "transforms the keys" do
         data = { :joe_camel_case => "what", :ninja_turtles => "cowabunga" }
-        expect(camelize_and_stringify_keys(data)).to eq("joeCamelCase" => "what", "ninjaTurtles" => "cowabunga")
+        expect(utils.camelize_and_stringify_keys(data)).to eq("joeCamelCase" => "what", "ninjaTurtles" => "cowabunga")
       end
     end
 
     context "structure is hashes nested in an array" do
       it "transforms the keys" do
         data = [{ :joe_camel_case => "what" }, { :ninja_turtles => "cowabunga" }]
-        expect(camelize_and_stringify_keys(data)).to eq([{ "joeCamelCase" => "what" }, { "ninjaTurtles" => "cowabunga" }])
+        expect(utils.camelize_and_stringify_keys(data)).to eq([{ "joeCamelCase" => "what" }, { "ninjaTurtles" => "cowabunga" }])
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ CONFIG = YAML.load_file("#{Dir.pwd}/spec/config.yml")
 
 VCR.configure do |config|
   config.cassette_library_dir = "spec/cassettes"
+  config.default_cassette_options = { match_requests_on: [:method, :uri, :body]}
   config.hook_into(:webmock)
   config.configure_rspec_metadata!
   config.filter_sensitive_data("<HOST>") { CONFIG["host"] }


### PR DESCRIPTION
Previously ruby client did not allow users to pass in optional params like `initialInvisibilityTime` for publishing and getting messages, or `errorIfExists` for creating queues. 